### PR TITLE
Update LangstoneGUI.c

### DIFF
--- a/LangstoneGUI.c
+++ b/LangstoneGUI.c
@@ -836,7 +836,7 @@ void setHwFreq(double fr)
      rxoffsethz=rxoffsethz-800;         //offset  for CW tone of 800 Hz
      txoffsethz=txoffsethz-800;     
     }
-	if(LOrxfreqhz!=lastLOhz);         
+	if(LOrxfreqhz!=lastLOhz)         
 	  {
   	  setPlutoFreq(LOrxfreqhz,LOtxfreqhz);          //Control Pluto directly to bypass problems with Gnu Radio Sink
   	  lastLOhz=LOrxfreqhz;
@@ -846,6 +846,7 @@ void setHwFreq(double fr)
 	sprintf(offsetStr,"O%d",rxoffsethz);   //send the rx offset tuning value 
 	sendFifo(offsetStr);
 	sprintf(offsetStr,"o%d",txoffsethz);   //send the Tx offset tuning value 
+	usleep(1000);
 	sendFifo(offsetStr);  
 }
 


### PR DESCRIPTION
Note master branch changes.
The Pluto LO Freq is currently updated on every tuning 'click' due to a semicolon at end of line839 - removed.
Delay added between sendFifo calls as fast tuning causes fifo write to fail sometimes, suspect gnuradio not responding fast enough.